### PR TITLE
docs: restructure README, document key composition, add edge case tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # conditions
 
-A fast, embeddable condition evaluator for Go. Parse expressions once, evaluate them repeatedly.
+A fast, embeddable condition evaluator for Go. **Parse once, evaluate many times.**
 
 ```go
 expr, _ := conditions.Parse(`{age} > 18 AND {status} == "active"`)
@@ -8,11 +8,17 @@ ok, _ := conditions.Evaluate(expr, map[string]interface{}{"age": 25, "status": "
 // ok == true
 ```
 
+---
+
 ## Install
 
 ```bash
 go get github.com/zhouzhuojie/conditions
 ```
+
+No external runtime dependencies — only the Go standard library.
+
+---
 
 ## Quick Start
 
@@ -25,17 +31,17 @@ import (
 )
 
 func main() {
-    // Parse once
-    expr, err := conditions.Parse(`({foo} > 0.45) AND ({bar} == "ON" OR {baz} IN ["ACTIVE", "CLEAR"])`)
+    // Parse once — use {group}{field} to reference grouped/nested fields
+    expr, err := conditions.Parse(`{product}{price} > 100 AND {product}{in_stock}`)
     if err != nil {
         panic(err)
     }
 
-    // Evaluate many times
+    // Evaluate many times — thread-safe, reuse across goroutines
+    // Data uses flat dotted keys: "product.price", "product.in_stock"
     data := map[string]interface{}{
-        "foo": 0.62,
-        "bar": "ON",
-        "baz": "ACTIVE",
+        "product.price":   150.00,
+        "product.in_stock": true,
     }
 
     result, err := conditions.Evaluate(expr, data)
@@ -43,16 +49,15 @@ func main() {
 }
 ```
 
-**Parse once, evaluate many times** — expressions are thread-safe and can be reused across goroutines:
+**Parse once, evaluate many times** — the parsed AST is immutable and safe to share:
 
 ```go
-expr, _ := conditions.Parse(`{price} * {qty} > 1000`)
+expr, _ := conditions.Parse(`{price} > 1000`)
 
 for _, order := range orders {
     go func(o Order) {
         ok, _ := conditions.Evaluate(expr, map[string]interface{}{
             "price": o.Price,
-            "qty":   o.Quantity,
         })
         if ok {
             flagForReview(o)
@@ -60,6 +65,8 @@ for _, order := range orders {
     }(order)
 }
 ```
+
+---
 
 ## Syntax
 
@@ -75,23 +82,92 @@ for _, order := range orders {
 
 ### Variables
 
-Variables are wrapped in `{curly braces}` and resolved from the `args` map at evaluation time:
+Variables reference values from the `args` map using `{curly braces}`.
 
-| Syntax | Args Key | Resolves To |
-|--------|----------|-------------|
-| `{foo}` | `"foo"` | `foo` |
-| `{foo}{bar}` | `"foo.bar"` | `foo.bar` |
-| `{foo}{bar}{baz}` | `"foo.bar.baz"` | `foo.bar.baz` |
-| `{@prefix}{key}` | `"@prefix.key"` | `@prefix.key` |
-| `{my-var}` | `"my-var"` | `my-var` |
+**Simple reference** — a single brace group maps directly to a map key:
+
+```
+{foo}   → args["foo"]
+{count} → args["count"]
+```
 
 ```go
-expr, _ := conditions.Parse(`{user}{name} == "Alice"`)
+expr, _ := conditions.Parse(`{status} == "active"`)
+ok, _ := conditions.Evaluate(expr, map[string]interface{}{"status": "active"})
+// ok == true
+```
+
+**Composing keys** — consecutive brace groups join with `.` into a single key:
+
+```
+{foo}{bar}      → args["foo.bar"]
+{foo}{bar}{baz} → args["foo.bar.baz"]
+```
+
+This is useful for **namespacing** or grouping related values without nesting your data:
+
+```go
+expr, _ := conditions.Parse(
+    `{user}{name} == "Alice" AND {user}{age} > 18`,
+)
 ok, _ := conditions.Evaluate(expr, map[string]interface{}{
     "user.name": "Alice",
+    "user.age":  25,
 })
 // ok == true
 ```
+
+> **How it works:** At parse time, consecutive `{...}` groups are detected and concatenated into a single dotted key. The evaluation does a flat lookup — `args["user.name"]` — it does **not** traverse into nested maps.
+
+**`@` prefix** — brace groups starting with `@` keep the `@` in the key:
+
+```
+{@env}{key}  → args["@env.key"]
+```
+
+Useful for namespacing under a well-known prefix (e.g., environment variables).
+
+**Hyphens** — variable names can contain hyphens:
+
+```
+{my-var}          → args["my-var"]
+{my-var}{sub-key} → args["my-var.sub-key"]
+```
+
+#### Limitations of key composition
+
+Before using composed keys (`{a}{b}`), understand what it **doesn't** do:
+
+| What you write | What it resolves to | What it does **not** do |
+|---|---|---|
+| `{user}{name}` | `args["user.name"]` (flat key) | `args["user"]["name"]` (nested map access) |
+| `{data}{items}` | `args["data.items"]` (flat key) | `args["data"]["items"]` (nested map access) |
+
+**Concrete example — what works vs what doesn't:**
+
+```go
+// ✅ Works: data is a flat map with dotted keys
+args := map[string]interface{}{
+    "user.name": "Alice",
+    "user.age":  25,
+}
+expr, _ := conditions.Parse(`{user}{name} == "Alice"`)
+ok, _ := conditions.Evaluate(expr, args) // true
+
+// ❌ Does NOT work: data is a nested map
+args := map[string]interface{}{
+    "user": map[string]interface{}{
+        "name": "Alice",
+        "age":  25,
+    },
+}
+// This will error — "user.name" key not found in the flat map
+```
+
+**When to use each:**
+
+- **Flat dotted keys (`{"user.name": "Alice"}`) + `{user}{name}`** — use when you control the data shape. Simple, fast, no nesting overhead.
+- **Nested maps (`{"user": {"name": "Alice"}}`)** — use when consuming JSON from external APIs (`json.Unmarshal` produces this shape). Note that the current expression syntax does not traverse nested maps — you must flatten the data before passing it to `Evaluate()`.
 
 ### Operators
 
@@ -104,7 +180,7 @@ ok, _ := conditions.Evaluate(expr, map[string]interface{}{
 | `XOR` | Exactly one true | `{a} XOR {b}` |
 | `NAND` | Not both true | `{a} NAND {b}` |
 
-`AND` and `OR` short-circuit — if the left side determines the result, the right side is never evaluated:
+`AND` and `OR` short-circuit — if the left side determines the result, the right side is never evaluated. This is especially useful when the right side would error on missing variables:
 
 ```go
 expr, _ := conditions.Parse(`{enabled} AND {missing_var}`)
@@ -128,7 +204,7 @@ ok, err := conditions.Evaluate(expr, map[string]interface{}{"enabled": false})
 Numbers use epsilon-based equality (default `1e-6`) for floating-point tolerance:
 
 ```go
-conditions.SetDefaultEpsilon(1e-9) // optional: change tolerance
+conditions.SetDefaultEpsilon(1e-9) // optional: change global tolerance
 ```
 
 **Pattern Matching:**
@@ -138,7 +214,7 @@ conditions.SetDefaultEpsilon(1e-9) // optional: change tolerance
 | `=~` | Matches regex | `{status} =~ /^5\d\d$/` |
 | `!~` | Does not match | `{path} !~ /\.json$/` |
 
-Patterns are compiled once and cached automatically.
+Patterns are compiled once and cached automatically (thread-safe).
 
 **Membership:**
 
@@ -149,7 +225,7 @@ Patterns are compiled once and cached automatically.
 | `CONTAINS` | Array contains value | `{tags} CONTAINS "urgent"` |
 | `NOT CONTAINS` | Array lacks value | `{tags} NOT CONTAINS "spam"` |
 
-`IN` and `CONTAINS` are O(1) for string arrays (uses hash map internally).
+`IN` and `CONTAINS` are O(1) for string arrays (backed by a hash map).
 
 ### Parentheses
 
@@ -159,47 +235,56 @@ Group expressions to control evaluation order:
 expr, _ := conditions.Parse(`({a} > 10 OR {b} > 10) AND {c} == true`)
 ```
 
+Without parentheses, operator precedence is: `OR`/`XOR` < `AND`/`NAND` < comparisons/membership/regex.
+
+---
+
 ## Supported Types
 
 The `args` map accepts these Go types:
 
 | Go Type | Treated As |
 |---------|-----------|
-| `int`, `int8-64` | Number |
-| `uint`, `uint8-64` | Number |
+| `int`, `int8`–`int64` | Number |
+| `uint`, `uint8`–`uint64` | Number |
 | `float32`, `float64` | Number |
 | `json.Number` | Number |
 | `string` | String |
 | `bool` | Boolean |
 | `[]string` | String array |
-| `[]int`, `[]int32-64` | Number array |
+| `[]int`, `[]int32`–`int64` | Number array |
 | `[]float32`, `[]float64` | Number array |
 | `[]json.Number` | Number array |
 | `[]interface{}` | Auto-detected (from JSON) |
 
+---
+
 ## API
 
 ```go
-// Parse a condition string
+// Parse a condition string into an AST expression.
+// The result is immutable and thread-safe.
 func Parse(condition string) (Expr, error)
 
-// Or use a parser with custom reader
+// Or use a parser with a custom io.Reader.
 func NewParser(r io.Reader) *Parser
 func (p *Parser) Parse() (Expr, error)
 
-// Evaluate a parsed expression
+// Evaluate a parsed expression against a set of arguments.
 func Evaluate(expr Expr, args map[string]interface{}) (bool, error)
 
-// Set float comparison tolerance (default: 1e-6)
-// Call before any concurrent Evaluate calls
+// Set float comparison tolerance (default: 1e-6).
+// Call before any concurrent Evaluate calls.
 func SetDefaultEpsilon(ep float64)
 
-// Extract variable names from a parsed expression
+// Extract the list of variable names referenced in an expression.
 func Variables(expression Expr) []string
 
-// Walk the AST
+// Walk the AST tree with a visitor function.
 func WalkFunc(expr Expr, fn func(Node))
 ```
+
+---
 
 ## Performance
 
@@ -207,15 +292,15 @@ Benchmarked on Apple M1 Max:
 
 | Operation | Time | Memory |
 |-----------|------|---------|
+| Short-circuit (`false AND ...`) | 6 ns/op | 0 B/op |
 | Simple comparison (`{foo} == "hello"`) | 33 ns/op | 16 B/op |
-| Numeric comparison (`{foo} > 100 AND < 200`) | 60 ns/op | 16 B/op |
 | Boolean operators (`{a} AND {b} OR {c}`) | 57 ns/op | 3 B/op |
+| Numeric comparison (`{foo} > 100 AND < 200`) | 60 ns/op | 16 B/op |
 | Regex match (`{status} =~ /^5\d\d/`) | 80 ns/op | 16 B/op |
 | String IN 5-element array | 40 ns/op | 16 B/op |
-| String IN 10K-element array | 41 ns/op | 16 B/op |
+| String IN 10,000-element array | 41 ns/op | 16 B/op |
 | `CONTAINS` check | 155 ns/op | 288 B/op |
 | `Variables()` extraction | 143 ns/op | 64 B/op |
-| Short-circuit (`false AND ...`) | 6 ns/op | 0 B/op |
 | Full expression parse | 1.1 μs/op | 1896 B/op |
 
 **Key optimizations:**
@@ -225,16 +310,19 @@ Benchmarked on Apple M1 Max:
 - Boolean singletons — no allocations for boolean results
 - Optimized `Variables()` — direct AST walk (44% faster than original)
 
+---
+
 ## Credit
 
 Forked from [oleksandr/conditions](https://github.com/oleksandr/conditions).
 
-Differences from the original:
+Key differences from the original:
 - Variable syntax: `[foo]` → `{foo}`
+- Key composition: `{user}{name}` → `args["user.name"]` (consecutive brace groups join with `.`)
 - Added `CONTAINS` / `NOT CONTAINS` operators
 - Float comparison with configurable epsilon tolerance
-- Hash map optimization for array `IN`/`CONTAINS`
+- Hash map optimization for array `IN` / `CONTAINS`
 - Removed redundant RWMutex, added regex caching
-- Short-circuit `AND`/`OR` evaluation
+- Short-circuit `AND` / `OR` evaluation
 - Support for `uint` types and `json.Number`
 - `Parse()` convenience function

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -45,3 +45,39 @@ func TestVariables(t *testing.T) {
 	assert.Contains(t, vars, "c")
 	assert.Contains(t, vars, "d")
 }
+
+func TestVariablesWithComposedKeys(t *testing.T) {
+	cond := `{user}{name} == "Alice" AND {user}{age} > 18`
+	p := NewParser(strings.NewReader(cond))
+	expr, err := p.Parse()
+	assert.NoError(t, err)
+
+	vars := Variables(expr)
+	assert.Contains(t, vars, "user.name")
+	assert.Contains(t, vars, "user.age")
+	assert.Equal(t, 2, len(vars))
+	assert.NotContains(t, vars, "user")
+	assert.NotContains(t, vars, "name")
+}
+
+func TestVariablesThreeLevelComposed(t *testing.T) {
+	cond := `{a}{b}{c} == 42`
+	p := NewParser(strings.NewReader(cond))
+	expr, err := p.Parse()
+	assert.NoError(t, err)
+
+	vars := Variables(expr)
+	assert.Contains(t, vars, "a.b.c")
+	assert.Equal(t, 1, len(vars))
+}
+
+func TestVariablesHyphenatedComposed(t *testing.T) {
+	cond := `{my-var}{sub-key} == "val"`
+	p := NewParser(strings.NewReader(cond))
+	expr, err := p.Parse()
+	assert.NoError(t, err)
+
+	vars := Variables(expr)
+	assert.Contains(t, vars, "my-var.sub-key")
+	assert.Equal(t, 1, len(vars))
+}

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -168,6 +168,68 @@ var validTestData = []struct {
 	// !~
 	{"{status} !~ /^5\\d\\d/", map[string]interface{}{"status": "500"}, false, false},
 	{"{status} !~ /^4\\d\\d/", map[string]interface{}{"status": "500"}, true, false},
+
+	// --- Key composition (concat) edge cases ---
+
+	// Number comparison with composed key
+	{`{user}{age} > 18`, map[string]interface{}{"user.age": 25.0}, true, false},
+	{`{user}{age} > 18`, map[string]interface{}{"user.age": 15.0}, false, false},
+
+	// IN with composed key
+	{`{user}{role} IN ["admin", "moderator"]`, map[string]interface{}{"user.role": "admin"}, true, false},
+	{`{user}{role} IN ["admin", "moderator"]`, map[string]interface{}{"user.role": "viewer"}, false, false},
+
+	// NOT IN with composed key
+	{`{user}{role} NOT IN ["banned"]`, map[string]interface{}{"user.role": "admin"}, true, false},
+	{`{user}{role} NOT IN ["banned"]`, map[string]interface{}{"user.role": "banned"}, false, false},
+
+	// CONTAINS with composed key
+	{`{user}{tags} CONTAINS "urgent"`, map[string]interface{}{"user.tags": []string{"urgent", "billing"}}, true, false},
+	{`{user}{tags} CONTAINS "urgent"`, map[string]interface{}{"user.tags": []string{"spam"}}, false, false},
+
+	// NOT CONTAINS with composed key
+	{`{user}{tags} NOT CONTAINS "spam"`, map[string]interface{}{"user.tags": []string{"urgent", "billing"}}, true, false},
+
+	// Regex with composed key
+	{`{user}{status} =~ /^5\d\d/`, map[string]interface{}{"user.status": "500"}, true, false},
+	{`{user}{status} =~ /^5\d\d/`, map[string]interface{}{"user.status": "400"}, false, false},
+
+	// Hyphenated names with composition
+	{`{my-var}{sub-key} == "val"`, map[string]interface{}{"my-var.sub-key": "val"}, true, false},
+	{`{my-var}{sub-key} == "wrong"`, map[string]interface{}{"my-var.sub-key": "val"}, false, false},
+
+	// Concat in both LHS and RHS
+	{`{a}{x} == {b}{y}`, map[string]interface{}{"a.x": "hello", "b.y": "hello"}, true, false},
+	{`{a}{x} == {b}{y}`, map[string]interface{}{"a.x": "hello", "b.y": "world"}, false, false},
+
+	// Concat inside parentheses
+	{`({user}{age} > 18)`, map[string]interface{}{"user.age": 25.0}, true, false},
+	{`(({user}{age} > 18))`, map[string]interface{}{"user.age": 25.0}, true, false},
+
+	// Four-level concatenation
+	{`{a}{b}{c}{d} == true`, map[string]interface{}{"a.b.c.d": true}, true, false},
+
+	// Concat with AND short-circuit
+	{`false AND {missing}{key}` + " == true", nil, false, false},
+
+	// Concat with OR short-circuit
+	{`true OR {missing}{key}` + " == true", nil, true, false},
+
+	// Concat in compound expression with various operators (parens required
+	// for correct precedence when mixing AND with =~)
+	{`{user}{age} > 18 AND {user}{role} IN ["admin"] AND ({user}{status} =~ /^A/)`,
+		map[string]interface{}{"user.age": 25.0, "user.role": "admin", "user.status": "Active"},
+		true, false},
+
+	// Error: composed key missing from args
+	{`{user}{missing} == true`, map[string]interface{}{"user.name": "Alice"}, false, true},
+
+	// Error: compose with missing second part
+	{`{a}{b} == true`, map[string]interface{}{"a.x": true}, false, true},
+
+	// Error: nested map does NOT work with composed keys — {user}{status}
+	// looks up args["user.status"], not args["user"]["status"]
+	{`{user}{status} == 100`, map[string]interface{}{"user": map[string]interface{}{"status": 100}}, false, true},
 }
 
 func TestValid(t *testing.T) {
@@ -228,6 +290,12 @@ func TestJSON(t *testing.T) {
 		{`{foo} not contains "123"`, `{"foo": ["124"]}`, true, false},
 		{`{foo} not contains "123"`, `{"foo": null}`, false, true},
 		{`{foo} not contains "123"`, `{}`, false, true},
+
+		// JSON interop with composed keys
+		{`{user}{name} == "Alice"`, `{"user.name": "Alice"}`, true, false},
+		{`{user}{age} > 18`, `{"user.age": 25}`, true, false},
+		{`{user}{role} IN ["admin"]`, `{"user.role": "admin"}`, true, false},
+		{`{user}{role} IN ["admin"]`, `{"user.role": "viewer"}`, false, false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

Restructures the README for readability and documents the **key composition** feature (`{foo}{bar}` → `args["foo.bar"]`) as a first-class concept with clear limitations. Adds 27 new test cases covering edge cases.

## Changes

### README (`README.md`)
- **Quick Start** now demonstrates `{group}{field}` composition with flat dotted keys
- **Variables** section expanded from a dense table into a narrative feature with subsections: simple reference, composing keys, `@` prefix, hyphens
- **Limitations** subsection added with a comparison table and side-by-side ✅/❌ examples explaining what composed keys do **not** do (no nested map traversal)
- Visual separators, better section hierarchy, and minor polish throughout

### Tests (`evaluator_test.go`, `analysis_test.go`)
- 23 new evaluator edge cases: number comparison, IN/NOT IN, CONTAINS/NOT CONTAINS, regex, hyphenated names, both-sides concat, nested parens, 4-level concat, short-circuit, missing key errors
- 4 new JSON interop tests with composed keys
- 3 new analysis tests verifying `Variables()` extracts composed keys correctly

## Backward Compatibility

No code changes — only documentation and tests. All existing behavior is preserved.