### PR TITLE
fix: properly unescape escape sequences in string literals

### DIFF
--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -976,3 +976,64 @@ func TestUnsupportedOperator(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported operator")
 }
+
+func TestStringEscapeSequences(t *testing.T) {
+	// String literals with escape sequences should be properly unescaped.
+	// Previously, the parser used the raw content between quotes, so
+	// "he said \"hey\"" would produce `he said \"hey\"` (with literal
+	// backslash) instead of `he said "hey"` (with actual quote chars).
+	t.Run("double-quote escape", func(t *testing.T) {
+		expr, err := Parse(`{s} == "he said \"hey\""`)
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": `he said "hey"`})
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("backslash escape", func(t *testing.T) {
+		expr, err := Parse(`{s} == "path\\to\\file"`)
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": `path\to\file`})
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	// Invalid Go escapes like \d, \. fall back to raw content for
+	// backward compatibility (used in EREG patterns).
+	t.Run("invalid escape fallback", func(t *testing.T) {
+		expr, err := Parse(`{s} =~ "\d+"`)
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": "123"})
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	// Simple strings without escapes should still work.
+	t.Run("simple string", func(t *testing.T) {
+		expr, err := Parse(`{s} == "hello"`)
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": "hello"})
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	// Regex literals /.../ should be unaffected.
+	t.Run("regex literal", func(t *testing.T) {
+		expr, err := Parse(`{s} =~ /\d+/`)
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": "123"})
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	// EREG with quoted string containing invalid escape + valid escape
+	t.Run("mixed escapes in EREG", func(t *testing.T) {
+		// \. is invalid Go escape → falls back to raw content
+		// regex engine interprets \. as literal dot → correct
+		expr, err := Parse(`{s} =~ ".+@example\.com"`)
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": "user@example.com"})
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+}

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -1036,4 +1036,77 @@ func TestStringEscapeSequences(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, result)
 	})
+
+	// Valid Go escapes that were previously treated as raw text
+	// should now produce their interpreted values.
+	t.Run("newline escape \\n", func(t *testing.T) {
+		expr, err := Parse("{s} == \"\\n\"")
+		assert.NoError(t, err)
+		// Match against real newline
+		result, err := Evaluate(expr, map[string]any{"s": "\n"})
+		assert.NoError(t, err)
+		assert.True(t, result)
+		// Should NOT match literal backslash-n
+		result, err = Evaluate(expr, map[string]any{"s": "\\n"})
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("tab escape \\t", func(t *testing.T) {
+		expr, err := Parse("{s} == \"\\t\"")
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": "\t"})
+		assert.NoError(t, err)
+		assert.True(t, result)
+		result, err = Evaluate(expr, map[string]any{"s": "\\t"})
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("carriage return escape \\r", func(t *testing.T) {
+		expr, err := Parse("{s} == \"\\r\"")
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": "\r"})
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("hex escape \\x41 produces A", func(t *testing.T) {
+		expr, err := Parse(`{s} == "\x41"`)
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": "A"})
+		assert.NoError(t, err)
+		assert.True(t, result)
+		result, err = Evaluate(expr, map[string]any{"s": "\\x41"})
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("unicode escape \\u0041 produces A", func(t *testing.T) {
+		expr, err := Parse(`{s} == "\u0041"`)
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": "A"})
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("unicode escape \\U00000041 produces A", func(t *testing.T) {
+		expr, err := Parse(`{s} == "\U00000041"`)
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": "A"})
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	// Empty string should still work
+	t.Run("empty string", func(t *testing.T) {
+		expr, err := Parse(`{s} == ""`)
+		assert.NoError(t, err)
+		result, err := Evaluate(expr, map[string]any{"s": ""})
+		assert.NoError(t, err)
+		assert.True(t, result)
+		result, err = Evaluate(expr, map[string]any{"s": "x"})
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
 }

--- a/parser.go
+++ b/parser.go
@@ -294,6 +294,18 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 		if len(lit) < 2 {
 			return nil, fmt.Errorf("invalid string literal: %s", lit)
 		}
+		// String literals ("..."): properly interpret Go escape sequences
+		// so that \" and \\ are correctly unescaped to " and \.
+		if lit[0] == '"' && lit[len(lit)-1] == '"' {
+			unquoted, err := strconv.Unquote(lit)
+			if err != nil {
+				// Invalid Go escape sequences (e.g. \d, \.) — fall back
+				// to raw content for backward compatibility.
+				return &StringLiteral{Val: lit[1 : len(lit)-1]}, nil
+			}
+			return &StringLiteral{Val: unquoted}, nil
+		}
+		// Regex literals (/.../): use raw content between delimiters.
 		return &StringLiteral{Val: lit[1 : len(lit)-1]}, nil
 	case NUMBER:
 		v, err := strconv.ParseFloat(lit, 64)


### PR DESCRIPTION
## What

Fix string literal parsing to properly interpret Go escape sequences like `\"` and `\\`.

## Why

Go's `text/scanner` returns raw escape sequences inside quoted strings **without interpreting them**. When the parser encounters `\"` inside a string, it gets the two raw bytes `\` and `"` instead of the intended `"` character. This means:

- `{s} == "he said \"hey\""` could never match a value containing `"` 
- `{s} == "path\\to\\file"` could never match a value containing `\`
- The only symptom was the raw `\"` being passed through as literal characters

## How

In `parseUnaryExpr`'s `STRING` case: use `strconv.Unquote(lit)` on the full string literal to properly interpret escape sequences.

**Fallback for invalid Go escapes**: When `Unquote` fails (e.g., `\d`, `\.` which are common in regex patterns but invalid in Go strings), fall back to the raw content between quotes. This preserves backward compatibility for EREG patterns.

## Backward Compatibility

- Simple strings like `"hello"` → unchanged
- Regex literals `/pattern/` → unchanged (not processed by Unquote)
- Invalid Go escapes like `"\d+"` → fall back to raw content `\d+` (same as before, just with `strconv.Unquote` error instead of Go scanner error)
- Valid Go escapes like `"\"\""` → now correctly unescaped to `"`
- Valid Go escapes like `"\\\\"` → now correctly unescaped to `\`

Closes openflagr/flagr#618 (together with the Flagr-side fix)
