### PR TITLE
perf: faster AND/OR evaluation (no global slice cache)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Repository Guidelines
+
+## Project Overview
+
+Go library **`github.com/zhouzhuojie/conditions`**: **parse once, evaluate many** — boolean DSL → immutable `Expr` AST, then `Evaluate(expr, map[string]interface{})`. JSON/FBP-friendly; stdlib-only at runtime (`testify` tests only). No `main` or CLI.
+
+- Docs: `README.md` · CI: `.github/workflows/ci.yml` (branch `master`)
+
+## Architecture & Data Flow
+
+**Single package `conditions` at repo root** — all `.go` and `*_test.go` files live here (no `src/`, `internal/`, `cmd/`).
+
+`Parse` → `parser.go` / `token.go` → `ast.go` → `Evaluate` (`evaluator.go`, `operators.go`, `resolve.go`, `regex.go`, `float.go`).
+
+**Public API:** `Parse`, `Evaluate`, `Variables`, `Walk`/`WalkFunc`, `SetDefaultEpsilon` (before concurrent eval).
+
+**Variables in expressions:** `{key}` flat; `{a.b}` / `{users[0]}` nested (`resolve.go`); `{foo}{bar}` → `foo.bar`. Parsed AST is goroutine-safe; set epsilon early if needed.
+
+## Development Commands
+
+```bash
+go test -v -race -cover ./...   # CI
+go test ./...
+go fmt ./...
+golangci-lint run ./...         # CI lint
+go test -bench=. ./...
+```
+
+Go **1.24** (`go.mod`). Format with `go fmt`; no Makefile/npm/Docker.
+
+## Code Conventions & Patterns
+
+- Errors via `(T, error)`; no panics on user data.
+- `AND`/`OR` short-circuit in `evaluator.go`.
+- `booleanFromExpr` fast path for `AND`/`OR`; `boolExpr` singletons for bool args (`evaluator.go`, `resolve.go`).
+- `applyIN` uses direct type switches (`operators.go`); string `IN`/`CONTAINS` maps built at parse (AST) or per-eval from args (no global slice cache).
+- Syntax/precedence changes: `parser.go`, `token.go`, `operators.go` + tests.
+- Binding/coercion changes: `resolve.go` + `evaluator_test.go` / `resolve_test.go`.
+- Table-driven tests; README examples in `TestReadme*` (`evaluator_test.go`).
+
+## Testing & QA
+
+Colocated `*_test.go`; benchmarks in `parser_bench_test.go`. CI: race + cover + golangci-lint. Extend table tests and README parity tests when behavior changes.

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Patterns are compiled once and cached automatically (thread-safe).
 | `CONTAINS` | Array contains value | `{tags} CONTAINS "urgent"` |
 | `NOT CONTAINS` | Array lacks value | `{tags} NOT CONTAINS "spam"` |
 
-`IN` and `CONTAINS` are O(1) for string arrays (backed by a hash map).
+`IN` and `CONTAINS` are O(1) for string arrays (hash map on the array literal — in the parsed rule for `IN ["a","b"]`, or built when binding `[]string` from `args` each evaluation).
 
 ### Parentheses
 
@@ -277,6 +277,7 @@ Without parentheses, operator precedence is: `OR`/`XOR` < `AND`/`NAND` < compari
 | `[]float32`, `[]float64` | Number array |
 | `[]json.Number` | Number array |
 | `[]interface{}` | Auto-detected (from JSON) |
+
 
 ---
 
@@ -308,20 +309,21 @@ func WalkFunc(expr Expr, fn func(Node))
 
 ## Performance
 
-Benchmarked on Apple M1 Max:
+Benchmarked on **linux/arm64** (parse once per benchmark, then `Evaluate` in loop; `go test -benchmem`):
 
 | Operation | Time | Memory |
-|-----------|------|---------|
-| Short-circuit (`false AND ...`) | 6 ns/op | 0 B/op |
-| Simple comparison (`{foo} == "hello"`) | 33 ns/op | 16 B/op |
-| Boolean operators (`{a} AND {b} OR {c}`) | 57 ns/op | 3 B/op |
-| Numeric comparison (`{foo} > 100 AND < 200`) | 60 ns/op | 16 B/op |
-| Regex match (`{status} =~ /^5\d\d/`) | 80 ns/op | 16 B/op |
-| String IN 5-element array | 40 ns/op | 16 B/op |
-| String IN 10,000-element array | 41 ns/op | 16 B/op |
-| `CONTAINS` check | 155 ns/op | 288 B/op |
-| `Variables()` extraction | 143 ns/op | 64 B/op |
-| Full expression parse | 1.1 μs/op | 1896 B/op |
+|-----------|------|--------|
+| Short-circuit (`false AND ...`) | 7 ns/op | 0 B/op |
+| Simple comparison (`{foo} == "hello"`) | 44 ns/op | 16 B/op |
+| Boolean operators (`{a} AND {b} OR {c}`) | 46 ns/op | 0 B/op |
+| Numeric comparison (`{foo} > 100 AND < 200`) | 74 ns/op | 16 B/op |
+| Regex match (`{status} =~ /^5\d\d/`) | 101 ns/op | 16 B/op |
+| String IN 5-element array | 48 ns/op | 16 B/op |
+| String IN 10,000-element array | 49 ns/op | 16 B/op |
+| `CONTAINS` check (`[]string` from args) | 200 ns/op | 288 B/op |
+| Nested path (`{user.name} == "Alice"`) | 50 ns/op | 16 B/op |
+| `Variables()` extraction | 172 ns/op | 64 B/op |
+| Full expression parse | 1.5 μs/op | 1896 B/op |
 
 **Key optimizations:**
 - String array hash map — `IN`/`CONTAINS` is O(1) regardless of array size

--- a/evaluator.go
+++ b/evaluator.go
@@ -52,9 +52,13 @@ func evalBinary(n *BinaryExpr, args map[string]interface{}) (Expr, error) {
 		if err != nil {
 			return falseExpr, err
 		}
-		lb, err := getBoolean(lv)
-		if err != nil {
-			return nil, err
+		lb, ok := booleanFromExpr(lv)
+		if !ok {
+			var err error
+			lb, err = getBoolean(lv)
+			if err != nil {
+				return nil, err
+			}
 		}
 		if !lb {
 			return falseExpr, nil
@@ -63,9 +67,13 @@ func evalBinary(n *BinaryExpr, args map[string]interface{}) (Expr, error) {
 		if err != nil {
 			return falseExpr, err
 		}
-		rb, err := getBoolean(rv)
-		if err != nil {
-			return nil, err
+		rb, ok := booleanFromExpr(rv)
+		if !ok {
+			var err error
+			rb, err = getBoolean(rv)
+			if err != nil {
+				return nil, err
+			}
 		}
 		return boolExpr(rb), nil
 	}
@@ -75,9 +83,13 @@ func evalBinary(n *BinaryExpr, args map[string]interface{}) (Expr, error) {
 		if err != nil {
 			return falseExpr, err
 		}
-		lb, err := getBoolean(lv)
-		if err != nil {
-			return nil, err
+		lb, ok := booleanFromExpr(lv)
+		if !ok {
+			var err error
+			lb, err = getBoolean(lv)
+			if err != nil {
+				return nil, err
+			}
 		}
 		if lb {
 			return trueExpr, nil
@@ -86,9 +98,13 @@ func evalBinary(n *BinaryExpr, args map[string]interface{}) (Expr, error) {
 		if err != nil {
 			return falseExpr, err
 		}
-		rb, err := getBoolean(rv)
-		if err != nil {
-			return nil, err
+		rb, ok := booleanFromExpr(rv)
+		if !ok {
+			var err error
+			rb, err = getBoolean(rv)
+			if err != nil {
+				return nil, err
+			}
 		}
 		return boolExpr(rb), nil
 	}
@@ -102,6 +118,14 @@ func evalBinary(n *BinaryExpr, args map[string]interface{}) (Expr, error) {
 		return falseExpr, err
 	}
 	return applyOperator(n.Op, lv, rv)
+}
+
+// booleanFromExpr returns (value, true) when e is a *BooleanLiteral.
+func booleanFromExpr(e Expr) (bool, bool) {
+	if b, ok := e.(*BooleanLiteral); ok {
+		return b.Val, true
+	}
+	return false, false
 }
 
 // boolExpr returns the singleton boolean literal.

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -373,7 +373,7 @@ func TestKeyCompositionCompound(t *testing.T) {
 	runTestCases(t, []testCase{
 		// Multiple operators; parens needed around regex for correct precedence
 		{cond: `{user}{age} > 18 AND {user}{role} IN ["admin"] AND ({user}{status} =~ /^A/)`,
-			args: map[string]interface{}{"user.age": 25.0, "user.role": "admin", "user.status": "Active"},
+			args:   map[string]interface{}{"user.age": 25.0, "user.role": "admin", "user.status": "Active"},
 			result: true},
 	})
 }
@@ -656,8 +656,8 @@ func TestMixedKeyCompositionAndPath(t *testing.T) {
 		// Both sides use different approaches
 		{cond: `{a}{flat} == "yes" AND {b.nested} == "ok"`,
 			args: map[string]interface{}{
-				"a.flat":   "yes",
-				"b":        map[string]interface{}{"nested": "ok"},
+				"a.flat": "yes",
+				"b":      map[string]interface{}{"nested": "ok"},
 			}, result: true},
 	})
 }

--- a/operators.go
+++ b/operators.go
@@ -114,30 +114,23 @@ func applyEREG(l, r Expr) (*BooleanLiteral, error) {
 // --- Membership (IN / CONTAINS) ---
 
 func applyIN(l, r Expr) (*BooleanLiteral, error) {
-	switch l.(type) {
+	switch lv := l.(type) {
 	case *StringLiteral:
-		a, err := getString(l)
-		if err != nil {
-			return nil, err
+		switch rv := r.(type) {
+		case *SliceStringLiteral:
+			_, found := rv.m[lv.Val]
+			return boolExpr(found), nil
+		default:
+			return nil, fmt.Errorf("literal is not a slice of string: %v", r)
 		}
-		b, err := getMapString(r)
-		if err != nil {
-			return nil, err
-		}
-		_, found := b[a]
-		return boolExpr(found), nil
 
 	case *NumberLiteral:
-		a, err := getNumber(l)
-		if err != nil {
-			return nil, err
+		sl, ok := r.(*SliceNumberLiteral)
+		if !ok {
+			return nil, fmt.Errorf("literal is not a slice of float64: %v", r)
 		}
-		b, err := getSliceNumber(r)
-		if err != nil {
-			return nil, err
-		}
-		for _, e := range b {
-			if float64Equal(a, e) {
+		for _, e := range sl.Val {
+			if float64Equal(lv.Val, e) {
 				return trueExpr, nil
 			}
 		}

--- a/parser.go
+++ b/parser.go
@@ -517,5 +517,3 @@ func (p *Parser) scanIndex() (int, error) {
 	}
 	return idx, nil
 }
-
-

--- a/resolve.go
+++ b/resolve.go
@@ -107,7 +107,7 @@ func valueToExpr(val interface{}) (Expr, error) {
 	case string:
 		return &StringLiteral{Val: v}, nil
 	case bool:
-		return &BooleanLiteral{Val: v}, nil
+		return boolExpr(v), nil
 	case json.Number:
 		f, err := v.Float64()
 		if err != nil {


### PR DESCRIPTION
## Summary

Speeds up evaluation on hot paths without caching eval-context `[]string` (avoids unbounded global memory growth).

## Changes

- **`evaluator.go`**: `booleanFromExpr` fast path for `AND`/`OR` — boolean subtrees avoid `getBoolean` error allocations (~46 ns, **0 B/op** on `BenchmarkBooleanOperators`).
- **`resolve.go`**: `boolExpr()` singletons for `bool` args.
- **`operators.go`**: `applyIN` uses direct type switches on `*StringLiteral` / `*SliceStringLiteral`.
- **`README.md`**: Performance table refreshed (**linux/arm64**, `go test -benchmem`); membership hash-map scope documented (AST vs per-eval from `args`).
- **`AGENTS.md`**: Repository guidelines for contributors/agents.

## Intentionally not included

- Global `[]string` literal cache — keyed eval-context slices risk stale results and process-lifetime growth.

## Benchmarks (linux/arm64)

| Benchmark | Before (approx) | After |
|-----------|-----------------|-------|
| BooleanOperators | ~71 ns, 3 allocs | **~46 ns, 0 allocs** |
| Short-circuit | ~7 ns | ~7 ns |
| CONTAINS (args `[]string`) | ~186 ns | ~200 ns (per-eval map build) |

## Test plan

- [x] `go test ./...`
- [x] CI: `go test -v -race -cover ./...`